### PR TITLE
Update updateUserAttribute requestBody and response structure

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -397,39 +397,34 @@ paths:
       summary: Update user attributes
       description: Updates a user's attributes based on the provided data.
       tags:
-        - attribute
+        - Users
       parameters:
         - name: id
           in: path
           required: true
-          description: The id of the user whose attributes are to be updated. 
+          description: The keycloak id of the user whose attributes are to be updated.
           schema:
             type: string
             format: uuid
         - name: attributeName
           in: path  
           required: true
-          description: The name of the attribute to be updated. Allowed attributes `isSeveraOptIn`.
+          description: The name of the attribute to be updated.
           schema:
             type: string
       requestBody:
-        description: updated user attributes
+        description: Email of the user whose attribute is being updated.
         required: true
         content:
           application/json:
             schema:
               type: object
-              description: Request to update a user's attribute
               required:
-                - id
-                - attributes
+                - email
               properties:
-                id:
+                email:
                   type: string
-                  format: uuid
-                  description: User's ID in Keycloak.
-                attributes:
-                  $ref: "#/components/schemas/Attributes" 
+                  description: Email of the user whose attribute is being updated.
       responses:
         "200":
           description: User attributes updated successfully  
@@ -1411,7 +1406,7 @@ components:
           description: User`s ID in Severa
         isActive:
           type: boolean
-          description: Defining is user is active e.g. is employed.
+          description: Defining if user is active e.g. is employed.
         vacationDaysByYear:
           type: array
           items:
@@ -1439,13 +1434,12 @@ components:
           type: string
           format: uuid
           description: User's ID in Keycloak.
-        updatedAttributes:
-          $ref: "#/components/schemas/Attributes"
-        updateFields:
-          type: array
-          items:
-            type: string
-          description: List of attribute names that were updated.
+        updatedKeycloakAttributes:
+          type: object
+          properties:
+            severaUserId:
+              type: string
+              description: User's ID in Severa.
         severaUser:
           $ref: "#/components/schemas/SeveraUser"
 
@@ -1462,7 +1456,6 @@ components:
         severaKeyword:
           type: string
           description: The keyword returned from Severa API that is associated with the user.
-
 
     Users-avatars:
       type: object
@@ -1659,6 +1652,9 @@ components:
           description: URL to the image of the software
         status:
           $ref: "#/components/schemas/SoftwareStatus"
+        review:
+          type: string
+          description: User review of the software
         createdBy:
           type: string
           description: User who created the software entry

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -409,7 +409,7 @@ paths:
         - name: attributeName
           in: path  
           required: true
-          description: The name of the attribute to be updated.
+          description: The name of the attribute to be updated. Allowed attributes `isSeveraOptIn`.
           schema:
             type: string
       requestBody:


### PR DESCRIPTION
- Refactored requestBody to only include `email`.
- `id` and `attributeName` are now passed as path parameters (not in the body).
- Updated response schema to reflect the correct structure.