### PR TITLE
Feature-114-Refactor-Opt-In-Endpoints

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -639,50 +639,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  "/users/{id}/attributes/{attributeName}":
-    put:
-      operationId: updateUserAttribute
-      summary: Update user attributes
-      description: Updates a user's attributes based on the provided data.
-      tags:
-        - Users
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: The keycloak id of the user whose attributes are to be updated.
-          schema:
-            type: string
-            format: uuid
-        - name: attributeName
-          in: path
-          required: true
-          description: The name of the attribute to be updated. Allowed attributes `isSeveraOptIn`.
-          schema:
-            type: string
-      requestBody:
-        description: Attribute update payload.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - value
-              properties:
-                value:
-                  type: string
-                  description: Value for the attribute being updated.
-      responses:
-        "200":
-          description: User attributes updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UpdateUserAttribute"
-        "default":
-          description: Invalid request was sent to the server.
-
   "/users/{userId}":
     get:
       operationId: findUser
@@ -712,7 +668,7 @@ paths:
     put:
       operationId: addSeveraOptIn
       summary: Add Severa opt-in for user
-      description: Add the user's Severa opt-in status.
+      description: Add the user's Severa opt-in status to both severa and keycloak.
       tags:
         - Users
       parameters:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -661,18 +661,18 @@ paths:
           schema:
             type: string
       requestBody:
-        description: Email of the user whose attribute is being updated.
+        description: Attribute update payload.
         required: true
         content:
           application/json:
             schema:
               type: object
               required:
-                - email
+                - value
               properties:
-                email:
+                value:
                   type: string
-                  description: Email of the user whose attribute is being updated.
+                  description: Value for the attribute being updated.
       responses:
         "200":
           description: User attributes updated successfully
@@ -709,6 +709,38 @@ paths:
           description: Invalid request was sent to the server.
 
   "/users/{userId}/severa-opt-in":
+    put:
+      operationId: addSeveraOptIn
+      summary: Add Severa opt-in for user
+      description: Add the user's Severa opt-in status.
+      tags:
+        - Users
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          description: The Keycloak ID of the user to add Severa opt-in for.
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Opt-in completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "default":
+          description: Invalid request was sent to the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
     delete:
       operationId: removeSeveraOptIn
       summary: Remove Severa opt-in for user


### PR DESCRIPTION
## What has been done
- Added **PUT** _/users/{userId}/severa-opt-in_ to expose opt-in as a new endpoint.
- Removed the email field from the requestBody of _/users/{id}/attributes/{attributeName}_, requiring only value.