### PR TITLE
Add id to Question and AnswerOption

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2667,6 +2667,10 @@ components:
         - questionText
         - answerOptions
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the question
         questionText:
           type: string
           description: The question text
@@ -2682,6 +2686,10 @@ components:
         - label
         - isCorrect
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the answer option
         label:
           type: string
           description: Display text for the answer option


### PR DESCRIPTION
Adding id to the properties of Question and AnswerOption to be able to solve the Sonarqube warning "Do not use Array index in keys". Id in the database is the way react documentation recommends.