### PR TITLE
Restored the get slack avatar endpoint

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8,26 +8,27 @@ security:
   - bearerAuth: []
 
 paths:
-  "/slack-avatar":
+  "/slack-avatar/{email}":
     get:
-      operationId: slackAvatar
-      summary: Lists users avatars
-      description: |
-        Lists users avatars
-        
-        **Endpoint not currently deployed; code retained, deployment disabled via serverless config.**
+      operationId: getSlackUserAvatarByEmail
+      summary: Get user's slack avatar by email
+      description: Fetches user's avatar from Slack by email
       tags:
-        - Slack avatars
-      x-status: inactive
+        - Slack
+      parameters:
+        - name: email
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
-          description: A list of images for forecast users
+          description: The URL of the user's Slack avatar 
           content:
             application/json;charset=utf-8:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Users-avatars"
+                type: string
+                format: uri
 
   "/pipedrive/salesLeads":
     get:
@@ -2335,15 +2336,6 @@ components:
         severaKeyword:
           type: string
           description: The keyword returned from Severa API that is associated with the user.
-
-    Users-avatars:
-      type: object
-      description: Users avatars data
-      properties:
-        personId:
-          type: integer
-        image_original:
-          type: string
 
     Skill:
       type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8,7 +8,7 @@ security:
   - bearerAuth: []
 
 paths:
-  "/slack-avatar/{email}":
+  "/slack-avatar":
     get:
       operationId: getSlackUserAvatarByEmail
       summary: Get user's slack avatar by email
@@ -17,18 +17,21 @@ paths:
         - Slack
       parameters:
         - name: email
-          in: path
+          in: query
           required: true
           schema:
             type: string
       responses:
         "200":
           description: The URL of the user's Slack avatar 
-          content:
-            application/json;charset=utf-8:
-              schema:
-                type: string
-                format: uri
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                image_original:
+                  type: string
+                  format: uri
 
   "/pipedrive/salesLeads":
     get:


### PR DESCRIPTION
Restored the get slack avatar endpoint and made the endpoint fetch only the slack avatar for individual user by their email.