### PR TITLE
Refactor SlackAvatarResponse: optional image_original, include reason when missing

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,24 +23,11 @@ paths:
             type: string
       responses:
         "200":
-          description: The URL of the user's Slack avatar 
+          description: Slack avatar response
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - image_original
-                properties:
-                  image_original:
-                    type: string
-                    format: uri
-                    nullable: true
-                  reason:
-                    type: string
-                    enum:
-                      - no_avatar
-                      - email_mismatch
-                      - unknown_error
+                $ref: '#/components/schemas/SlackAvatarResponse'
 
   "/pipedrive/salesLeads":
     get:
@@ -3151,3 +3138,19 @@ components:
           type: string
         contentType:
           type: string
+    
+    SlackAvatarResponse:
+      type: object
+      required:
+        - image_original
+      properties:
+        image_original:
+          type: string
+          format: uri
+          nullable: true
+        reason:
+          type: string
+          enum:
+            - no_avatar
+            - email_mismatch
+            - unknown_error

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -32,6 +32,7 @@ paths:
                   image_original:
                     type: string
                     format: uri
+                    nullable: true
 
   "/pipedrive/salesLeads":
     get:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Slack avatar response
+          description: Returns the user's Slack avatar URL or error information if unavailable
           content:
             application/json:
               schema:
@@ -3141,6 +3141,7 @@ components:
     
     SlackAvatarResponse:
       type: object
+      description: Response containing Slack avatar information. Returns image_original when available, or reason when the avatar cannot be retrieved.
       required:
         - image_original
       properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3142,16 +3142,19 @@ components:
     SlackAvatarResponse:
       type: object
       description: Response containing Slack avatar information. Returns image_original when available, or reason when the avatar cannot be retrieved.
-      required:
-        - image_original
       properties:
         image_original:
           type: string
           format: uri
-          nullable: true
         reason:
           type: string
           enum:
             - no_avatar
             - email_mismatch
             - unknown_error
+          description: >
+            Indicates why an avatar is unavailable. This field is populated 
+            only when `image_original` is null or absent.  
+            - `no_avatar`: Slack user exists but has no avatar set.  
+            - `email_mismatch`: No Slack user matches the provided email.  
+            - `unknown_error`: An unexpected error occurred while fetching the avatar.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -28,11 +28,19 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - image_original
                 properties:
                   image_original:
                     type: string
                     format: uri
                     nullable: true
+                  reason:
+                    type: string
+                    enum:
+                      - no_avatar
+                      - email_mismatch
+                      - unknown_error
 
   "/pipedrive/salesLeads":
     get:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3141,9 +3141,9 @@ components:
     
     SlackAvatarResponse:
       type: object
-      description: Response containing Slack avatar information. Returns image_original when available, or reason when the avatar cannot be retrieved.
+      description: Response containing Slack avatar information. Returns imageOriginal when available, or reason when the avatar cannot be retrieved.
       properties:
-        image_original:
+        imageOriginal:
           type: string
           format: uri
         reason:
@@ -3151,10 +3151,8 @@ components:
           enum:
             - no_avatar
             - email_mismatch
-            - unknown_error
           description: >
             Indicates why an avatar is unavailable. This field is populated 
-            only when `image_original` is null or absent.  
+            only when `imageOriginal` is null or absent.  
             - `no_avatar`: Slack user exists but has no avatar set.  
             - `email_mismatch`: No Slack user matches the provided email.  
-            - `unknown_error`: An unexpected error occurred while fetching the avatar.


### PR DESCRIPTION
Made the image_original to be omitted if there is no value and created a schema for the 200 response, so that the reason enums will use that generated type in the handler