### PR TITLE
spec update

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -976,6 +976,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserRolesResponse"
+        "400":
+          description: Invalid user ID supplied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref:"#/components/schemas/Error"
         
     put:
       operationId: updateUserRoles
@@ -3661,11 +3679,3 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Role"
-
-    SuccessMessage:
-      type: object
-      properties:
-        message:
-          type: string
-          example: Roles updated successfully      
-  

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -950,7 +950,153 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"              
+                $ref: "#/components/schemas/Error"
+                
+   "/users/{userId}/roles":
+    get:
+      operationId: getUserRoles
+      summary: Get user roles
+      description: Retrieve roles assigned to a user from Keycloak
+      tags:
+        - Users
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: List of roles assigned to the user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  example: developer
+
+    put:
+      operationId: updateUserRoles
+      summary: Update user roles
+      description: |
+        Allows users to self-select roles. Updates roles in Keycloak. Restricted roles (e.g. admin) cannot be assigned by users.
+      tags:
+        - Users
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - roles
+              properties:
+                roles:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - developer
+                    - designer
+      responses:
+        "200":
+          description: Roles updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Roles updated successfully
+        "400":
+          description: Invalid roles provided
+        "403":
+          description: Attempt to assign restricted roles
+
+  "/software/recommended":
+    get:
+      operationId: getRecommendedSoftware
+      summary: Get recommended software
+      description: Returns software filtered based on user roles
+      tags:
+        - Software
+      parameters:
+        - name: roles
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Filtered software list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SoftwareRegistry"
+
+  "/articles/recommended":
+    get:
+      operationId: getRecommendedArticles
+      summary: Get recommended articles
+      description: Returns articles filtered based on user roles
+      tags:
+        - Article
+      parameters:
+        - name: roles
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Filtered articles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArticleMetadata"
+
+  "/questionnaires/recommended":
+    get:
+      operationId: getRecommendedQuestionnaires
+      summary: Get recommended questionnaires
+      description: Returns questionnaires filtered based on user roles
+      tags:
+        - Questionnaires
+      parameters:
+        - name: roles
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Filtered questionnaires
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Questionnaire"                            
 
   "/questionnaires":
     get:
@@ -3554,3 +3700,29 @@ components:
           type: integer
           description: Number of vacations that ended
           example: 2
+  ArticleMetadata:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            type: string
+          description: Roles this article is recommended for
+
+  SoftwareRegistry:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            type: string
+          description: Roles this software is recommended for
+
+  Questionnaire:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            type: string
+          description: Roles this questionnaire is intended for

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -512,8 +512,6 @@ paths:
         - name: roles
           in: query
           required: false
-          style: form
-          explode: true
           schema:
             type: array
             items:
@@ -967,7 +965,8 @@ paths:
       operationId: getUserRoles
       summary: Get user roles
       description: Retrieve roles assigned to a user from Keycloak
-      tags: [Users]
+      tags:
+        - Users
       parameters:
         - $ref: "#/components/parameters/UserId"
       responses:
@@ -1016,8 +1015,6 @@ paths:
         - name: roles
           in: query
           required: false
-          style: form
-          explode: true
           schema:
             type: array
             items:
@@ -2180,8 +2177,6 @@ paths:
         - name: roles  
           in: query
           required: false
-          style: form
-          explode: true
           schema:
             type: array
             items:
@@ -2530,13 +2525,13 @@ components:
       bearerFormat: JWT
 
   parameters:
-  UserId:
-    name: userId
-    in: path
-    required: true
-    schema:
-      type: string
-      format: uuid  
+    UserId:
+      name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid  
 
   schemas:
     Error:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -508,6 +508,16 @@ paths:
       description: Retrieve a list of all software entries in the registry.
       tags:
         - Software
+      parameters:
+        - name: roles
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Role"
       responses:
         "200":
           description: A list of software entries
@@ -952,31 +962,22 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
                 
-   "/users/{userId}/roles":
+  "/users/{userId}/roles":
     get:
       operationId: getUserRoles
       summary: Get user roles
       description: Retrieve roles assigned to a user from Keycloak
-      tags:
-        - Users
+      tags: [Users]
       parameters:
-        - name: userId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
+        - $ref: "#/components/parameters/UserId"
       responses:
         "200":
           description: List of roles assigned to the user
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
-                  example: developer
-
+                $ref: "#/components/schemas/UserRolesResponse"
+        
     put:
       operationId: updateUserRoles
       summary: Update user roles
@@ -985,118 +986,24 @@ paths:
       tags:
         - Users
       parameters:
-        - name: userId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
+          - $ref: "#/components/parameters/UserId"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - roles
-              properties:
-                roles:
-                  type: array
-                  items:
-                    type: string
-                  example:
-                    - developer
-                    - designer
+              $ref: "#/components/schemas/UpdateUserRolesRequest"
       responses:
         "200":
           description: Roles updated successfully
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: Roles updated successfully
+                $ref: "#/components/schemas/SuccessMessage"
         "400":
           description: Invalid roles provided
         "403":
           description: Attempt to assign restricted roles
-
-  "/software/recommended":
-    get:
-      operationId: getRecommendedSoftware
-      summary: Get recommended software
-      description: Returns software filtered based on user roles
-      tags:
-        - Software
-      parameters:
-        - name: roles
-          in: query
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-      responses:
-        "200":
-          description: Filtered software list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/SoftwareRegistry"
-
-  "/articles/recommended":
-    get:
-      operationId: getRecommendedArticles
-      summary: Get recommended articles
-      description: Returns articles filtered based on user roles
-      tags:
-        - Article
-      parameters:
-        - name: roles
-          in: query
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-      responses:
-        "200":
-          description: Filtered articles
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ArticleMetadata"
-
-  "/questionnaires/recommended":
-    get:
-      operationId: getRecommendedQuestionnaires
-      summary: Get recommended questionnaires
-      description: Returns questionnaires filtered based on user roles
-      tags:
-        - Questionnaires
-      parameters:
-        - name: roles
-          in: query
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-      responses:
-        "200":
-          description: Filtered questionnaires
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Questionnaire"                            
 
   "/questionnaires":
     get:
@@ -1105,6 +1012,16 @@ paths:
       description: Retrieve a list of all questionnaires in the registry.
       tags:
         - Questionnaires
+      parameters:
+        - name: roles
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Role"  
       responses:
         "200":
           description: A list of questionnaires
@@ -2260,6 +2177,15 @@ paths:
           description: Get draft articles.
           schema:
             type: boolean
+        - name: roles  
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Role"
       responses:
         "200":
           description: List of articles.
@@ -2602,6 +2528,15 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+
+  parameters:
+  UserId:
+    name: userId
+    in: path
+    required: true
+    schema:
+      type: string
+      format: uuid  
 
   schemas:
     Error:
@@ -3700,29 +3635,42 @@ components:
           type: integer
           description: Number of vacations that ended
           example: 2
-  ArticleMetadata:
-      type: object
-      properties:
-        roles:
-          type: array
-          items:
-            type: string
-          description: Roles this article is recommended for
 
-  SoftwareRegistry:
-      type: object
-      properties:
-        roles:
-          type: array
-          items:
-            type: string
-          description: Roles this software is recommended for
+    Role:  
+      type: string
+      enum:
+        - developer
+        - designer
+        - architect
+        - admin
+        - management
+        - trainee
 
-  Questionnaire:
+    UserRolesResponse:
       type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/Role"
+
+    UpdateUserRolesRequest:
+      type: object
+      required:
+        - roles
       properties:
         roles:
           type: array
           items:
-            type: string
-          description: Roles this questionnaire is intended for
+            $ref: "#/components/schemas/Role"
+
+    SuccessMessage:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Roles updated successfully      
+  


### PR DESCRIPTION
This change introduces role-based personalization to the system.
Users can now select their job roles (e.g. developer, designer), which are stored in Keycloak. These roles are then used to personalize different parts of the application.
Software recommendations can be filtered based on roles
Wiki articles can be targeted to specific roles
Questionnaires can be suggested based on user roles
Overall, this allows the system to provide a more relevant and user-specific experience instead of showing the same content to everyone.

